### PR TITLE
Update to Cake.Frosting 0.31.0

### DIFF
--- a/src/RavinduL.SEStandard.Build/NuGet.Config
+++ b/src/RavinduL.SEStandard.Build/NuGet.Config
@@ -1,6 +1,0 @@
-<configuration>
-	<packageSources>
-		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-		<add key="myget.org" value="https://www.myget.org/F/cake/api/v3/index.json" protocolVersion="3" />
-	</packageSources>
-</configuration>

--- a/src/RavinduL.SEStandard.Build/RavinduL.SEStandard.Build.csproj
+++ b/src/RavinduL.SEStandard.Build/RavinduL.SEStandard.Build.csproj
@@ -5,9 +5,9 @@
 		<StartupObject>RavinduL.SEStandard.Build.Program</StartupObject>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Cake.Frosting" Version="0.1.0-alpha0068" />
+		<PackageReference Include="Cake.Frosting" Version="0.31.0" />
 		<PackageReference Include="Handlebars.Net" Version="1.9.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+		<PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
 		<PackageReference Include="System.ValueTuple" Version="4.4.0" />
 	</ItemGroup>
 	<ProjectExtensions><VisualStudio><UserProperties CodeGen_4Data_4Sets_4Enums_1json__JSONSchema="Enums.schema.json" CodeGen_4Data_4Sets_4Methods_1json__JSONSchema="Methods.schema.json" CodeGen_4Data_4Sets_4Classes_1json__JSONSchema="Classes.schema.json" /></VisualStudio></ProjectExtensions>


### PR DESCRIPTION
* Uses Cake.Core & Cake.Common 0.31.0 ( read more about improvements at https://cakebuild.net/blog/2018/12/cake-v0.31.0-released )
* 0.31.0 is on NuGet.org so nuget.config no longer needed